### PR TITLE
bug: fix grammar for capturing swap status.

### DIFF
--- a/grammar.go
+++ b/grammar.go
@@ -46,7 +46,7 @@ type Object struct {
 	// Ticks is the number of execution ticks spent in this object.
 	Ticks int ` "(" @Int ")"`
 	// SwapStatus is a string describing the swap status (if any).
-	SwapStatus string ` ("PROG SWAPPED"|"VAR SWAPPED"|"SWAPPED")? `
+	SwapStatus string ` @("PROG" "SWAPPED"|"VAR" "SWAPPED"|"SWAPPED")? `
 	// The time the object was created.
 	Created string ` @Date `
 }


### PR DESCRIPTION
### Description

The LDMUD `OBJ_DUMP` format includes a field for object swap status that can have one of the following values:

> nothing if not swapped,
> 'PROG SWAPPED' if only the program is swapped
> 'VAR SWAPPED' if only the variables are swapped
> 'SWAPPED' if both program and variables are swapped

Previous to this commit a line with one of the non-empty statuses for object swap status would fail to parse, producing an error like:

```
ERROR: backfilling db: parsing: OBJ_DUMP.swaps:1:109: unexpected token "VAR" (expected <date>)
```

### Bugs

This happened because the `SwapStatus` grammar included string literals that had interior whitespace, e.g. `"PROG SWAPPED"`, when they should instead match two individual literals in sequence: e.g. `"PROG" "SWAPPED"`. We tokenize and ignore whitespace separately.

Beyond this bug, the grammar on the `SwapStatus` field was also missing the `@` to capture the parsed value.

### Testing

<details><summary>Testing with `OBJ_DUMP.swaps`</summary>

```bash
$> cat OBJ_DUMP.swaps
d/Matres/guild/obj/corpse#1793361   883 ( 1009) ref 12    d/Ix/paradox/spire/rooms/info_nook#1671098  (581) VAR SWAPPED 2021.12.03-22:45:22
d/Ix/paradox/spire/objs/pants#1766418  2135 ( 2825) ref 13    d/Ix/paradox/spire/rooms/generator_room#1670864  (16725) PROG SWAPPED 2021.12.03-19:21:44
d/Ix/paradox/spire/objs/shirt#1766417  2119 ( 2886) ref 13    d/Ix/paradox/spire/rooms/generator_room#1670864  (16505) SWAPPED 2021.12.03-19:21:44
```

```bash
$> ~/go/bin/dumpdb OBJ_DUMP.swaps
INFO: Using database file "OBJ_DUMP.sqlite"
INFO: Reading OBJ_DUMP from "OBJ_DUMP.swaps"
INFO: Parsing OBJ_DUMP into AST
INFO: Inserting object info into DB
INFO: Finished inserts.
INFO: Loaded 3 objects from "OBJ_DUMP.swaps" into DB "OBJ_DUMP.sqlite"
```

```bash
$> sqlite3 OBJ_DUMP.sqlite
SQLite version 3.34.1 2021-01-20 14:10:07
Enter ".help" for usage hints.
sqlite> SELECT DISTINCT swap_status FROM obj_dump;
VARSWAPPED
PROGSWAPPED
SWAPPED
```
</details>