### PR TITLE
feat: don't add to existing DBs by default.

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,14 @@ func infoPrint(msg string, args ...interface{}) {
 
 func main() {
 	dbFile := flag.String("db", "OBJ_DUMP.sqlite", "SQLite Database file path to populate")
+	forceFlag := flag.Bool("force", false, "Add OBJ_DUMP data to an existing database")
 	flag.Parse()
+
+	if _, err := os.Stat(*dbFile); err == nil && !(*forceFlag) {
+		errPrint(
+			"db %q exists and -force was not specified. Remove the database or add -force\n",
+			*dbFile)
+	}
 
 	// Open the database.
 	db, err := openDB(*dbFile)


### PR DESCRIPTION
### Description

This tool is presently built around the idea that it translates one OBJ_DUMP file into one DB. It gets confusing if you were to run the tool twice with the same arguments. Prior to this commit it would in fact add the same contents twice and 2x the data without any clear indication that it was two separate imports.

### Feature
In this commit we add a `-force` flag that defaults to false. If given a `-db` path that already exists, but `-force` is not true, then an error is printed about the existing db and we abort. If `-force` is true, then we assume the user knows what they are doing and we add the file's rows to the existing DB.