### PR TITLE
feat: add a --version flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ git clone https://github.com/dune-mud/dumpdb.git && cd dumpdb
 ```
 * Build and install
 ```bash
-go install ./...
+go install -ldflags "-X main.commit=$(git rev-parse HEAD)" ./...
 ```
 * Run the `dumpdb` executable from your Go bin.
 ```bash

--- a/main.go
+++ b/main.go
@@ -6,6 +6,13 @@ import (
 	"os"
 )
 
+// goreleaser updates these at build time. These are the defaults used
+// for a native Go build with no ldflags overrides.
+var (
+	version = "dev"
+	commit  = "unknown"
+)
+
 // errPrint prints a formatted message to stderr and exits non-zero.
 func errPrint(msg string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, "ERROR: "+msg, args...)
@@ -20,7 +27,13 @@ func infoPrint(msg string, args ...interface{}) {
 func main() {
 	dbFile := flag.String("db", "OBJ_DUMP.sqlite", "SQLite Database file path to populate")
 	forceFlag := flag.Bool("force", false, "Add OBJ_DUMP data to an existing database")
+	versionFlag := flag.Bool("version", false, "Print the version and quit")
 	flag.Parse()
+
+	if *versionFlag {
+		infoPrint("dumpdb version %s - commit %s\n", version, commit)
+		os.Exit(0)
+	}
 
 	if _, err := os.Stat(*dbFile); err == nil && !(*forceFlag) {
 		errPrint(


### PR DESCRIPTION
### Description

Release builds will have the correct `version` and `commit` set at build time using `ldflags`. The README is updated to describe setting the `ldflags` correctly to pick up your local build SHA for development builds from source that don't use `goreleaser`. This should be helpful for knowing which version of the tool you're using.